### PR TITLE
allow partial resolution

### DIFF
--- a/crates/diman_unit_system/src/codegen/debug.rs
+++ b/crates/diman_unit_system/src/codegen/debug.rs
@@ -38,7 +38,7 @@ impl Defs {
                         }
                     };
                     let val = self.0.representative_value();
-                    let units = #units;
+                    let units: &[(#dimension_type, _, _)] = &#units;
                     let (unit_name, unit_value) = units
                         .iter()
                         .filter(|(d, _, _)| d == &D)

--- a/crates/diman_unit_system/src/lib.rs
+++ b/crates/diman_unit_system/src/lib.rs
@@ -53,13 +53,7 @@ pub fn unit_system(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let defs = parse_macro_input!(item as parse::types::Defs);
     let defs: types::UnresolvedDefs = defs.verify().unwrap();
     let resolved = defs.resolve();
-    match resolved {
-        Ok(resolved) => resolved.code_gen().into(),
-        Err(e) => {
-            e.emit();
-            proc_macro::TokenStream::new()
-        }
-    }
+    resolved.code_gen().into()
 }
 
 /// Derives all required methods for a dimension type.

--- a/crates/diman_unit_system/src/resolve/mod.rs
+++ b/crates/diman_unit_system/src/resolve/mod.rs
@@ -16,8 +16,20 @@ use self::{
     resolver::Resolver,
 };
 
+/// A helper function for emitting all the errors contained in the
+/// result types but continuing with a partial result anyways This is
+/// done so that we at least define all the quantities that can be
+/// partially resolved in order to keep the amount of error messages
+/// manageable.
+fn emit_errors<T>((input, result): (T, Result<()>)) -> T {
+    if let Err(err) = result {
+        err.emit();
+    }
+    input
+}
+
 impl UnresolvedDefs {
-    pub fn resolve(self) -> Result<Defs> {
+    pub fn resolve(self) -> Defs {
         let items: Vec<UnresolvedItem> = self
             .quantities
             .iter()
@@ -25,19 +37,19 @@ impl UnresolvedDefs {
             .chain(self.units.iter().map(|u| u.to_unresolved_item()))
             .chain(self.constants.iter().map(|u| u.to_unresolved_item()))
             .collect();
-        check_no_undefined_identifiers(&items)?;
-        check_no_multiply_defined_identifiers(&items)?;
-        let mut items = Resolver::resolve(items)?;
-        let quantities = convert_vec_to_resolved(self.quantities, &mut items);
-        let units = convert_vec_to_resolved(self.units, &mut items);
-        let constants = convert_vec_to_resolved(self.constants, &mut items);
-        Ok(Defs {
+        let items = emit_errors(filter_undefined_identifiers(items));
+        let items = emit_errors(filter_multiply_defined_identifiers(items));
+        let mut resolved_items = emit_errors(Resolver::resolve(items));
+        let quantities = convert_vec_to_resolved(self.quantities, &mut resolved_items);
+        let units = convert_vec_to_resolved(self.units, &mut resolved_items);
+        let constants = convert_vec_to_resolved(self.constants, &mut resolved_items);
+        Defs {
             dimension_type: self.dimension_type,
             quantity_type: self.quantity_type,
             quantities,
             units,
             constants,
-        })
+        }
     }
 }
 
@@ -46,19 +58,21 @@ fn convert_vec_to_resolved<T: ItemConversion>(
     items: &mut HashMap<Ident, ResolvedItem>,
 ) -> Vec<T::Resolved> {
     ts.into_iter()
-        .map(|t| {
-            let item = items.remove(t.ident()).unwrap();
-            t.into_resolved(item)
+        .filter_map(|t| {
+            let item = items.remove(t.ident());
+            item.map(|item| t.into_resolved(item))
         })
         .collect()
 }
 
-fn check_no_multiply_defined_identifiers(items: &[UnresolvedItem]) -> Result<()> {
+fn filter_multiply_defined_identifiers(
+    items: Vec<UnresolvedItem>,
+) -> (Vec<UnresolvedItem>, Result<()>) {
     let mut counter: HashMap<_, usize> = items.iter().map(|item| (&item.name, 0)).collect();
     for item in items.iter() {
         *counter.get_mut(&item.name).unwrap() += 1;
     }
-    if items.as_ref().iter().any(|item| counter[&item.name] > 1) {
+    let err = if items.iter().any(|item| counter[&item.name] > 1) {
         Err(Error::Multiple(
             counter
                 .iter()
@@ -74,32 +88,49 @@ fn check_no_multiply_defined_identifiers(items: &[UnresolvedItem]) -> Result<()>
         ))
     } else {
         Ok(())
-    }
+    };
+    (items, err)
 }
 
-fn check_no_undefined_identifiers(items: &[UnresolvedItem]) -> Result<()> {
-    let lhs_idents: HashSet<Ident> = items.iter().map(|item| item.name.clone()).collect();
-    let mut undefined_rhs_idents = vec![];
-    for item in items.iter() {
-        match &item.val {
-            ValueOrExpr::Value(_) => {}
-            ValueOrExpr::Expr(expr) => {
-                for val in expr.iter_vals() {
-                    match val {
-                        IdentOrFactor::Factor(_) => {}
-                        IdentOrFactor::Ident(ident) => {
-                            if !lhs_idents.contains(ident) {
-                                undefined_rhs_idents.push(ident.clone());
-                            }
-                        }
+fn get_rhs_idents(item: &UnresolvedItem) -> Vec<&Ident> {
+    let mut rhs_idents = vec![];
+    match &item.val {
+        ValueOrExpr::Value(_) => {}
+        ValueOrExpr::Expr(expr) => {
+            for val in expr.iter_vals() {
+                match val {
+                    IdentOrFactor::Factor(_) => {}
+                    IdentOrFactor::Ident(ident) => {
+                        rhs_idents.push(ident);
                     }
                 }
             }
         }
     }
-    if undefined_rhs_idents.is_empty() {
+    rhs_idents
+}
+
+fn filter_undefined_identifiers(items: Vec<UnresolvedItem>) -> (Vec<UnresolvedItem>, Result<()>) {
+    let lhs_idents: HashSet<Ident> = items.iter().map(|item| item.name.clone()).collect();
+    let (defined, undefined): (Vec<_>, Vec<_>) = items.into_iter().partition(|item| {
+        get_rhs_idents(item)
+            .iter()
+            .all(|rhs_ident| lhs_idents.contains(rhs_ident))
+    });
+
+    let err = if undefined.is_empty() {
         Ok(())
     } else {
-        Err(Error::Undefined(undefined_rhs_idents))
-    }
+        let mut undefined_rhs = vec![];
+        for item in undefined {
+            let rhs_idents = get_rhs_idents(&item);
+            for rhs_ident in rhs_idents {
+                if !lhs_idents.contains(rhs_ident) {
+                    undefined_rhs.push(rhs_ident.clone());
+                }
+            }
+        }
+        Err(Error::Undefined(undefined_rhs))
+    };
+    (defined, err)
 }

--- a/crates/diman_unit_system/src/resolve/resolver.rs
+++ b/crates/diman_unit_system/src/resolve/resolver.rs
@@ -18,13 +18,14 @@ pub struct Resolver<U, R> {
 }
 
 impl<U: Resolvable<Resolved = R>, R> Resolver<U, R> {
-    pub fn resolve(unresolved: Vec<U>) -> Result<HashMap<Ident, R>> {
+    pub fn resolve(unresolved: Vec<U>) -> (HashMap<Ident, R>, Result<()>) {
         let mut resolver = Self {
             unresolved,
             resolved: HashMap::new(),
         };
-        resolver.run()?;
-        Ok(resolver.resolved)
+
+        let result = resolver.run();
+        (resolver.resolved, result)
     }
 
     fn run(&mut self) -> Result<()> {

--- a/tests/compile_fail/resolver_partial_resolution.rs
+++ b/tests/compile_fail/resolver_partial_resolution.rs
@@ -1,0 +1,27 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs, adt_const_params)]
+
+use diman::dimension;
+use diman::unit_system;
+
+#[dimension]
+pub struct Dimension {
+    pub length: i32,
+}
+
+unit_system!(
+    Quantity,
+    Dimension,
+    [
+        def Length = { length: 1 },
+        unit (meters, "m") = Length,
+        unit (kilometers, "km") = 1000.0 * meters,
+        unit (millimeters, "mm") = 0.001 * meters,
+        unit (undefined, "u") = undefined,
+    ]
+);
+
+fn main() {
+    use crate::f64::*;
+    let l = Length::meters(1.0);
+}

--- a/tests/compile_fail/resolver_partial_resolution.stderr
+++ b/tests/compile_fail/resolver_partial_resolution.stderr
@@ -1,0 +1,7 @@
+error: Unresolvable definition "undefined".
+  --> tests/compile_fail/resolver_partial_resolution.rs:20:15
+   |
+20 |         unit (undefined, "u") = undefined,
+   |               ^^^^^^^^^
+   |
+   = help: Remove recursive definitions.


### PR DESCRIPTION
implements partial resolution of units and dimensions. this means that a single undefined/unresolved/duplicate definition does not prevent all the other types from generating. this helps keep compiler output clean in large code bases.

solves #12 