### PR TITLE
use From<Quantity> for dimensionless float methods

### DIFF
--- a/crates/diman_unit_system/src/codegen/float_methods.rs
+++ b/crates/diman_unit_system/src/codegen/float_methods.rs
@@ -110,16 +110,16 @@ impl Defs {
                     #quantity_type::<#float_type, { D.dimension_cbrt() }>(self.0.cbrt())
                 }
 
-                pub fn min(self, other: Self) -> Self {
-                    Self(self.0.min(other.0))
+                pub fn min<Q: Into<Self>>(self, other: Q) -> Self {
+                    Self(self.0.min(other.into().0))
                 }
 
-                pub fn max(self, other: Self) -> Self {
-                    Self(self.0.max(other.0))
+                pub fn max<Q: Into<Self>>(self, other: Q) -> Self {
+                    Self(self.0.max(other.into().0))
                 }
 
-                pub fn clamp(self, min: Self, max: Self) -> Self {
-                    Self(self.0.clamp(min.0, max.0))
+                pub fn clamp<Q: Into<Self>>(self, min: Q, max: Q) -> Self {
+                    Self(self.0.clamp(min.into().0, max.into().0))
                 }
 
                 pub fn zero() -> Self {

--- a/crates/diman_unit_system/src/codegen/traits.rs
+++ b/crates/diman_unit_system/src/codegen/traits.rs
@@ -671,10 +671,12 @@ impl Defs {
             .collect();
         let sum = self.impl_sum();
         let neg = self.impl_neg();
+        let from = self.impl_from();
         quote! {
             #ops
             #sum
             #neg
+            #from
         }
     }
 
@@ -740,6 +742,24 @@ impl Defs {
                     Self(-self.0)
                 }
             }
+        }
+    }
+
+    fn impl_from(&self) -> TokenStream {
+        let Self {
+            quantity_type,
+            dimension_type,
+            ..
+        } = self;
+        quote! {
+            impl<S> From<S>
+                for #quantity_type<S, { #dimension_type::none() }>
+            {
+                fn from(other: S) -> Self {
+                    Self(other)
+                }
+            }
+
         }
     }
 }

--- a/tests/float/mod.rs
+++ b/tests/float/mod.rs
@@ -294,6 +294,59 @@ macro_rules! gen_tests_for_float {
                 let y = Dimensionless::dimensionless(49.0);
                 assert!(x > y);
             }
+
+            #[test]
+            fn clamp_quantity_quantity() {
+                let x = Length::meters(10.0);
+                let y = Length::kilometers(20.0);
+                assert!(Length::meters(1.0).clamp(x, y) == x);
+                assert!(Length::meters(50.0).clamp(x, y) == Length::meters(50.0));
+                assert!(Length::meters(50000.0).clamp(x, y) == y);
+            }
+
+            #[test]
+            fn clamp_quantity_type() {
+                let x = 10.0;
+                let y = 20.0;
+                assert!(Dimensionless::dimensionless(5.0).clamp(x, y) == x);
+                assert!(
+                    Dimensionless::dimensionless(15.0).clamp(x, y)
+                        == Dimensionless::dimensionless(15.0)
+                );
+                assert!(Dimensionless::dimensionless(50.0).clamp(x, y) == y);
+            }
+
+            #[test]
+            fn max_quantity_quantity() {
+                let x = Length::meters(10.0);
+                assert!(Length::meters(5.0).max(x) == x);
+                assert!(Length::meters(15.0).max(x) == Length::meters(15.0));
+            }
+
+            #[test]
+            fn max_quantity_type() {
+                let x = 10.0;
+                assert!(Dimensionless::dimensionless(5.0).max(x) == x);
+                assert!(
+                    Dimensionless::dimensionless(15.0).max(x) == Dimensionless::dimensionless(15.0)
+                );
+            }
+
+            #[test]
+            fn min_quantity_quantity() {
+                let x = Length::meters(10.0);
+                assert!(Length::meters(5.0).min(x) == Length::meters(5.0));
+                assert!(Length::meters(15.0).min(x) == x);
+            }
+
+            #[test]
+            fn min_quantity_type() {
+                let x = 10.0;
+                assert!(
+                    Dimensionless::dimensionless(5.0).min(x) == Dimensionless::dimensionless(5.0)
+                );
+                assert!(Dimensionless::dimensionless(15.0).min(x) == x);
+            }
         }
     };
 }


### PR DESCRIPTION
This allows using `Quantity::clamp`, `Quantity::max` and `Quantity::min` directly with floats for dimensionless quantities while still retaining the ability to call it with quantities (of matching dimension)