### PR TITLE
Rational dimensions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,10 +32,12 @@ jobs:
           sudo apt-get install mpich
       - name: Build
         run: cargo build --verbose --all-targets
-      - name: Run tests (all features)
-        run: cargo test --tests --all-features
       - name: Run tests (default features)
         run: cargo test --tests
+      - name: Run tests (all features, no rational dimensions)
+        run: cargo test --tests --features glam,glam-vec2,glam-dvec2,glam-vec3,glam-dvec3,f32,f64,gen-vec-names,si,mpi,hdf5,rand,serde
+      - name: Run tests (all features)
+        run: cargo test --tests --all-features
       - name: Doctests
         run: cargo test --doc --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ f32 = ["diman_unit_system/f32"]
 f64 = ["diman_unit_system/f64"]
 gen-vec-names = ["diman_unit_system/gen-vec-names"]
 si = []
+rational-dimensions = ["diman_unit_system/rational-dimensions"]
 
 mpi = ["dep:once_cell", "dep:mpi", "diman_unit_system/mpi"]
 hdf5 = ["dep:hdf5", "diman_unit_system/hdf5"]

--- a/README.md
+++ b/README.md
@@ -178,12 +178,18 @@ fn bar(l: Length, t: Time) -> Quotient<Length, Time> {
 ```
 
 ## Rational dimensions
-The `rational-dimensions` feature allows using quantities with rational exponents in their base dimensions, as opposed to just integer values. This allows expressing writing expressions such as
+The `rational-dimensions` feature allows using quantities with rational exponents in their base dimensions, as opposed to just integer values. This allows expressing defining dimensions and units such as
 ```rust ignore
-let x = Length::meters(10.0);
-let foo = x.sqrt();
+dimension Sorptivity = Length Time^(-1/2);
+unit meters_per_sqrt_second: Sorptivity = meters / seconds^(1/2);
 ```
-Without `rational-dimensions`, this would not be allowed, since the dimension of foo is L^(1/2).
+and using them in the usual manner
+```rust ignore
+let l = Length::micrometers(2.0);
+let t = Time::milliseconds(5.0);
+let sorptivity: Sorptivity = l / t.sqrt();
+```
+
 The unit system generated with `rational-dimensions` supports a superset of features of a unit system generated without them.
 Still, this feature should be enabled only when necessary, since the compiler errors in case of dimension mismatches will be harder to read.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you cannot use unstable Rust for your project or require a stable library, co
 * Invalid operations between physical quantities (adding length and time, for example) turn into compile errors.
 * Newly created quantities are automatically converted to an underlying base representation. This means that the used types are dimensions (such as `Length`) instead of concrete units (such as `meters`) which makes for more meaningful code.
 * Systems of dimensions and units can be user defined via the `unit_system!` macro. This gives the user complete freedom over the choice of dimensions and makes them part of the user's library, so that arbitrary new methods can be implemented on them.
+* The `rational-dimensions` features allows the usage of quantities and units with rational exponents.
 * `f32` and `f64` float storage types (behind the `f32` and `f64` feature gate respectively).
 * Vector storage types via [`glam`](https://crates.io/crates/glam/) (behind the `glam-vec2`, `glam-vec3`, `glam-dvec2` and `glam-dvec3` features).
 * Serialization and Deserialization via [`serde`](https://crates.io/crates/serde) (behind the `serde` feature gate, see the official documentation for more info).
@@ -175,6 +176,16 @@ fn bar(l: Length, t: Time) -> Quotient<Length, Time> {
     l / t
 }
 ```
+
+## Rational dimensions
+The `rational-dimensions` feature allows using quantities with rational exponents in their base dimensions, as opposed to just integer values. This allows expressing writing expressions such as
+```rust ignore
+let x = Length::meters(10.0);
+let foo = x.sqrt();
+```
+Without `rational-dimensions`, this would not be allowed, since the dimension of foo is L^(1/2).
+The unit system generated with `rational-dimensions` supports a superset of features of a unit system generated without them.
+Still, this feature should be enabled only when necessary, since the compiler errors in case of dimension mismatches will be harder to read.
 
 ## `serde`
 Serialization and deserialization of the units is provided via `serde` if the `serde` feature gate is enabled:

--- a/crates/diman_unit_system/Cargo.toml
+++ b/crates/diman_unit_system/Cargo.toml
@@ -22,6 +22,7 @@ serde = []
 rand = []
 hdf5 = []
 gen-vec-names = [] 
+rational-dimensions = []
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "extra-traits"] }

--- a/crates/diman_unit_system/src/codegen/base_dimension_type.rs
+++ b/crates/diman_unit_system/src/codegen/base_dimension_type.rs
@@ -1,12 +1,18 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
-use crate::types::Defs;
+use crate::types::{BaseDimensionExponent, Defs};
 
 #[cfg(feature = "rational-dimensions")]
 impl Defs {
-    pub fn get_base_dimenison_entry(&self, field: &Ident, value: &i32) -> TokenStream {
-        quote! { #field: Ratio::int(#value), }
+    pub fn get_base_dimenison_entry(
+        &self,
+        field: &Ident,
+        value: &BaseDimensionExponent,
+    ) -> TokenStream {
+        let num = value.num;
+        let denom = value.denom;
+        quote! { #field: Ratio { num: #num, denom: #denom }, }
     }
 
     pub fn base_dimension_type(&self) -> TokenStream {
@@ -64,7 +70,12 @@ impl Defs {
 
 #[cfg(not(feature = "rational-dimensions"))]
 impl Defs {
-    pub fn get_base_dimenison_entry(&self, field: &Ident, value: &i32) -> TokenStream {
+    pub fn get_base_dimenison_entry(
+        &self,
+        field: &Ident,
+        value: &BaseDimensionExponent,
+    ) -> TokenStream {
+        let value = value.0;
         quote! { #field: #value, }
     }
 

--- a/crates/diman_unit_system/src/codegen/base_dimension_type.rs
+++ b/crates/diman_unit_system/src/codegen/base_dimension_type.rs
@@ -13,41 +13,41 @@ impl Defs {
         quote! { Ratio }
     }
 
-    pub fn zero(&self, ident: &Ident) -> TokenStream {
+    pub fn zero_entry(&self, ident: &Ident) -> TokenStream {
         quote! { #ident: Ratio::int(0), }
     }
 
-    pub fn add(&self, ident: &Ident) -> TokenStream {
+    pub fn add_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident.add(other.#ident),
         }
     }
 
-    pub fn sub(&self, ident: &Ident) -> TokenStream {
+    pub fn sub_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident.sub(other.#ident),
         }
     }
 
-    pub fn neg(&self, ident: &Ident) -> TokenStream {
+    pub fn neg_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident.neg(),
         }
     }
 
-    pub fn mul(&self, ident: &Ident) -> TokenStream {
+    pub fn mul_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident.mul(Ratio::int(other)),
         }
     }
 
-    pub fn sqrt(&self, ident: &Ident) -> TokenStream {
+    pub fn sqrt_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident.div(Ratio::int(2)),
         }
     }
 
-    pub fn cbrt(&self, ident: &Ident) -> TokenStream {
+    pub fn cbrt_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident.div(Ratio::int(3)),
         }
@@ -72,41 +72,41 @@ impl Defs {
         quote! { i32 }
     }
 
-    pub fn zero(&self, ident: &Ident) -> TokenStream {
+    pub fn zero_entry(&self, ident: &Ident) -> TokenStream {
         quote! { #ident: 0, }
     }
 
-    pub fn add(&self, ident: &Ident) -> TokenStream {
+    pub fn add_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident + other.#ident,
         }
     }
 
-    pub fn sub(&self, ident: &Ident) -> TokenStream {
+    pub fn sub_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident - other.#ident,
         }
     }
 
-    pub fn neg(&self, ident: &Ident) -> TokenStream {
+    pub fn neg_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: -self.#ident,
         }
     }
 
-    pub fn mul(&self, ident: &Ident) -> TokenStream {
+    pub fn mul_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident * other,
         }
     }
 
-    pub fn sqrt(&self, ident: &Ident) -> TokenStream {
+    pub fn sqrt_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident / 2,
         }
     }
 
-    pub fn cbrt(&self, ident: &Ident) -> TokenStream {
+    pub fn cbrt_entry(&self, ident: &Ident) -> TokenStream {
         quote! {
             #ident: self.#ident / 3,
         }

--- a/crates/diman_unit_system/src/codegen/dimension_def.rs
+++ b/crates/diman_unit_system/src/codegen/dimension_def.rs
@@ -1,22 +1,6 @@
 use quote::quote;
-use syn::Ident;
 
 use crate::types::Defs;
-
-fn str_to_snakecase(s: &str) -> String {
-    let s = s.chars().rev().collect::<String>();
-    let words = s.split_inclusive(|c: char| c.is_uppercase());
-    words
-        .map(|word| word.chars().rev().collect::<String>().to_lowercase())
-        .rev()
-        .collect::<Vec<_>>()
-        .join("_")
-}
-
-pub fn to_snakecase(dim: &proc_macro2::Ident) -> Ident {
-    let snake_case = str_to_snakecase(&dim.to_string());
-    Ident::new(&snake_case, dim.span())
-}
 
 impl Defs {
     pub(crate) fn dimension_impl(&self) -> proc_macro::TokenStream {
@@ -214,18 +198,5 @@ impl Defs {
 
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn str_to_snakecase() {
-        assert_eq!(super::str_to_snakecase("MyType"), "my_type".to_owned());
-        assert_eq!(super::str_to_snakecase("My"), "my".to_owned());
-        assert_eq!(
-            super::str_to_snakecase("MyVeryLongType"),
-            "my_very_long_type".to_owned()
-        );
     }
 }

--- a/crates/diman_unit_system/src/codegen/dimension_def.rs
+++ b/crates/diman_unit_system/src/codegen/dimension_def.rs
@@ -131,6 +131,9 @@ impl Defs {
         quote! {}
     }
 
+    /// Defines the `Ratio` type inside the calling crate.
+    /// This is done to improve error messages, since the
+    /// messages would otherwise show diman::Ratio everywhere.
     #[cfg(feature = "rational-dimensions")]
     fn ratio_impl(&self) -> proc_macro2::TokenStream {
         quote! {

--- a/crates/diman_unit_system/src/codegen/dimension_entry_type.rs
+++ b/crates/diman_unit_system/src/codegen/dimension_entry_type.rs
@@ -1,0 +1,130 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+
+use crate::types::Defs;
+
+#[cfg(feature = "rational-dimensions")]
+impl Defs {
+    pub fn get_base_dimenison_entry(&self, field: &Ident, value: &i32) -> TokenStream {
+        quote! { #field: Ratio::int(#value), }
+    }
+
+    pub fn base_dimension_type(&self) -> TokenStream {
+        quote! { Ratio }
+    }
+
+    pub fn zero(&self, ident: &Ident) -> TokenStream {
+        quote! { #ident: Ratio::int(0), }
+    }
+
+    pub fn add(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident.add(other.#ident),
+        }
+    }
+
+    pub fn sub(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident.sub(other.#ident),
+        }
+    }
+
+    pub fn neg(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident.neg(),
+        }
+    }
+
+    pub fn mul(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident.mul(Ratio::int(other)),
+        }
+    }
+
+    pub fn sqrt(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident.div(Ratio::int(2)),
+        }
+    }
+
+    pub fn cbrt(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident.div(Ratio::int(3)),
+        }
+    }
+
+    pub fn sqrt_safety(&self, _ident: &Ident) -> TokenStream {
+        quote! {}
+    }
+
+    pub fn cbrt_safety(&self, _ident: &Ident) -> TokenStream {
+        quote! {}
+    }
+}
+
+#[cfg(not(feature = "rational-dimensions"))]
+impl Defs {
+    pub fn get_base_dimenison_entry(&self, field: &Ident, value: &i32) -> TokenStream {
+        quote! { #field: #value, }
+    }
+
+    pub fn base_dimension_type(&self) -> TokenStream {
+        quote! { i32 }
+    }
+
+    pub fn zero(&self, ident: &Ident) -> TokenStream {
+        quote! { #ident: 0, }
+    }
+
+    pub fn add(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident + other.#ident,
+        }
+    }
+
+    pub fn sub(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident - other.#ident,
+        }
+    }
+
+    pub fn neg(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: -self.#ident,
+        }
+    }
+
+    pub fn mul(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident * other,
+        }
+    }
+
+    pub fn sqrt(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident / 2,
+        }
+    }
+
+    pub fn cbrt(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            #ident: self.#ident / 3,
+        }
+    }
+
+    pub fn sqrt_safety(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            if self.#ident % 2 != 0 {
+                panic!("Cannot take square root of quantity with a dimension that is not divisible by 2 in all components.");
+            }
+        }
+    }
+
+    pub fn cbrt_safety(&self, ident: &Ident) -> TokenStream {
+        quote! {
+            if self.#ident % 3 != 0 {
+                panic!("Cannot take cubic root of quantity with a dimension that is not divisible by 3 in all components.");
+            }
+        }
+    }
+}

--- a/crates/diman_unit_system/src/codegen/mod.rs
+++ b/crates/diman_unit_system/src/codegen/mod.rs
@@ -1,5 +1,5 @@
+mod base_dimension_type;
 mod debug;
-mod dimension_entry_type;
 mod float_methods;
 mod generic_methods;
 #[cfg(feature = "hdf5")]

--- a/crates/diman_unit_system/src/codegen/mod.rs
+++ b/crates/diman_unit_system/src/codegen/mod.rs
@@ -1,4 +1,5 @@
 mod debug;
+mod dimension_entry_type;
 mod float_methods;
 mod generic_methods;
 #[cfg(feature = "hdf5")]

--- a/crates/diman_unit_system/src/codegen/mod.rs
+++ b/crates/diman_unit_system/src/codegen/mod.rs
@@ -1,5 +1,6 @@
 mod base_dimension_type;
 mod debug;
+mod dimension_def;
 mod float_methods;
 mod generic_methods;
 #[cfg(feature = "hdf5")]

--- a/crates/diman_unit_system/src/codegen/type_defs.rs
+++ b/crates/diman_unit_system/src/codegen/type_defs.rs
@@ -67,9 +67,7 @@ impl Defs {
         let field_updates: TokenStream = dim
             .fields
             .iter()
-            .map(|(ident, value)| {
-                quote! { #ident: #value, }
-            })
+            .map(|(field, value)| self.get_base_dimenison_entry(field, value))
             .collect();
         let span = self.quantity_type.span();
         quote_spanned! {span =>
@@ -98,6 +96,16 @@ impl Defs {
             .collect()
     }
 
+    #[cfg(feature = "rational-dimensions")]
+    fn use_ratio(&self) -> TokenStream {
+        quote! { use super::Ratio; }
+    }
+
+    #[cfg(not(feature = "rational-dimensions"))]
+    fn use_ratio(&self) -> TokenStream {
+        quote! {}
+    }
+
     pub fn definitions_for_storage_type<T: StorageType>(
         &self,
         type_: &T,
@@ -118,10 +126,12 @@ impl Defs {
         } else {
             quote! {}
         };
+        let use_ratio = self.use_ratio();
         quote! {
             pub mod #module_name {
                 use super::#dimension_type;
                 use super::#quantity_type;
+                #use_ratio
                 #quantities
                 #constants
             }

--- a/crates/diman_unit_system/src/codegen/type_defs.rs
+++ b/crates/diman_unit_system/src/codegen/type_defs.rs
@@ -71,6 +71,7 @@ impl Defs {
             .collect();
         let span = self.quantity_type.span();
         quote_spanned! {span =>
+                #[allow(clippy::needless_update)]
                 #dimension_type {
                     #field_updates
                     ..#dimension_type::none()

--- a/crates/diman_unit_system/src/derive_dimension.rs
+++ b/crates/diman_unit_system/src/derive_dimension.rs
@@ -49,37 +49,37 @@ impl Defs {
         let type_name = &self.dimension_type;
         let none_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.zero(ident))
+            .map(|ident| self.zero_entry(ident))
             .collect();
 
         let mul_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.add(ident))
+            .map(|ident| self.add_entry(ident))
             .collect();
 
         let div_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.sub(ident))
+            .map(|ident| self.sub_entry(ident))
             .collect();
 
         let inv_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.neg(ident))
+            .map(|ident| self.neg_entry(ident))
             .collect();
 
         let powi_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.mul(ident))
+            .map(|ident| self.mul_entry(ident))
             .collect();
 
         let sqrt_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.sqrt(ident))
+            .map(|ident| self.sqrt_entry(ident))
             .collect();
 
         let cbrt_gen: proc_macro2::TokenStream = self
             .base_dimensions()
-            .map(|ident| self.cbrt(ident))
+            .map(|ident| self.cbrt_entry(ident))
             .collect();
 
         let sqrt_safety_gen: proc_macro2::TokenStream = self

--- a/crates/diman_unit_system/src/dimension_math.rs
+++ b/crates/diman_unit_system/src/dimension_math.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use proc_macro2::Ident;
 
-use crate::expression::MulDiv;
+use crate::{expression::MulDiv, types::BaseDimensionExponent};
 
 #[derive(Clone)]
 pub struct BaseDimensions {
-    pub fields: HashMap<Ident, i32>,
+    pub fields: HashMap<Ident, BaseDimensionExponent>,
 }
 
 impl PartialEq for BaseDimensions {
@@ -65,7 +65,7 @@ impl std::ops::Div for BaseDimensions {
 }
 
 impl MulDiv for BaseDimensions {
-    fn powi(self, pow: i32) -> Self {
+    fn pow(self, pow: BaseDimensionExponent) -> Self {
         BaseDimensions {
             fields: self
                 .fields
@@ -121,10 +121,10 @@ impl std::ops::Div for DimensionsAndFactor {
 }
 
 impl MulDiv for DimensionsAndFactor {
-    fn powi(self, pow: i32) -> Self {
+    fn pow(self, pow: BaseDimensionExponent) -> Self {
         Self {
-            factor: self.factor.powi(pow),
-            dimensions: self.dimensions.powi(pow),
+            factor: BaseDimensionExponent::pow(self.factor, pow),
+            dimensions: self.dimensions.pow(pow),
         }
     }
 }

--- a/crates/diman_unit_system/src/expression.rs
+++ b/crates/diman_unit_system/src/expression.rs
@@ -1,4 +1,4 @@
-use crate::types::IntExponent;
+use crate::types::BaseDimensionExponent;
 
 #[derive(Clone)]
 #[cfg_attr(test, derive(PartialEq, Debug))]
@@ -44,7 +44,7 @@ pub enum Factor<T, E> {
 pub trait MulDiv:
     std::ops::Mul<Output = Self> + std::ops::Div<Output = Self> + Sized + Clone
 {
-    fn powi(self, pow: i32) -> Self;
+    fn pow(self, pow: BaseDimensionExponent) -> Self;
 }
 
 impl<T, E> Expr<T, E> {
@@ -122,7 +122,7 @@ impl<T, E> Factor<T, E> {
     }
 }
 
-impl<T: MulDiv, I: Into<IntExponent> + Clone> Expr<T, I> {
+impl<T: MulDiv, I: Into<BaseDimensionExponent> + Clone> Expr<T, I> {
     pub fn eval(&self) -> T {
         match self {
             Expr::Value(val) => val.eval(),
@@ -138,19 +138,20 @@ impl<T: MulDiv, I: Into<IntExponent> + Clone> Expr<T, I> {
     }
 }
 
-impl<T: MulDiv, I: Into<IntExponent> + Clone> Factor<T, I> {
+impl<T: MulDiv, I: Into<BaseDimensionExponent> + Clone> Factor<T, I> {
     pub fn eval(&self) -> T {
         match self {
             Factor::Value(val) => val.clone(),
             Factor::ParenExpr(expr) => expr.eval(),
-            Factor::Power(val, exponent) => val.clone().powi(exponent.clone().into()),
+            Factor::Power(val, exponent) => val.clone().pow(exponent.clone().into()),
         }
     }
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "rational-dimensions"))]
 mod tests {
-    use crate::parse::tests::MyInt;
+    use crate::{parse::tests::MyInt, types::BaseDimensionExponent};
     use quote::quote;
 
     use super::{super::parse::tests::parse_expr, MulDiv};
@@ -172,14 +173,14 @@ mod tests {
     }
 
     impl MulDiv for MyInt {
-        fn powi(self, pow: i32) -> Self {
-            Self(self.0.pow(pow as u32))
+        fn pow(self, pow: BaseDimensionExponent) -> Self {
+            Self(self.0.pow(pow.0 as u32))
         }
     }
 
-    impl From<MyInt> for i32 {
+    impl From<MyInt> for BaseDimensionExponent {
         fn from(value: MyInt) -> Self {
-            value.0
+            BaseDimensionExponent(value.0)
         }
     }
 

--- a/crates/diman_unit_system/src/lib.rs
+++ b/crates/diman_unit_system/src/lib.rs
@@ -1,13 +1,13 @@
 #![feature(proc_macro_diagnostic)]
 
 mod codegen;
-mod derive_dimension;
 mod dimension_math;
 mod expression;
 mod parse;
 mod prefixes;
 mod resolve;
 mod storage_types;
+mod to_snakecase;
 mod types;
 
 use proc_macro2::TokenStream;

--- a/crates/diman_unit_system/src/resolve/error.rs
+++ b/crates/diman_unit_system/src/resolve/error.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use proc_macro::{Diagnostic, Level};
 use syn::Ident;
 
-use crate::dimension_math::BaseDimensions;
+use crate::{dimension_math::BaseDimensions, types::BaseDimensionExponent};
 
 use super::ident_storage::Kind;
 
@@ -89,7 +89,10 @@ fn format_lhs_rhs_dimensions(lhs: &BaseDimensions, rhs: &BaseDimensions) -> (Str
         available_dims
             .iter()
             .map(|dim| {
-                let value = *dims.fields.get(dim).unwrap_or(&0);
+                let value = *dims
+                    .fields
+                    .get(dim)
+                    .unwrap_or(&BaseDimensionExponent::zero());
                 format!("{}^{}", dim, value)
             })
             .collect::<Vec<_>>()

--- a/crates/diman_unit_system/src/resolve/ident_storage.rs
+++ b/crates/diman_unit_system/src/resolve/ident_storage.rs
@@ -6,8 +6,8 @@ use crate::{
     dimension_math::{BaseDimensions, DimensionsAndFactor},
     expression::{self, Expr},
     types::{
-        Constant, ConstantEntry, Definition, Dimension, DimensionEntry, Factor, IntExponent, Unit,
-        UnitEntry,
+        BaseDimensionExponent, Constant, ConstantEntry, Definition, Dimension, DimensionEntry,
+        Factor, Unit, UnitEntry,
     },
 };
 
@@ -40,7 +40,7 @@ impl Kind {
 
 #[derive(Clone)]
 pub struct Item {
-    expr: Expr<Factor<DimensionsAndFactor>, IntExponent>,
+    expr: Expr<Factor<DimensionsAndFactor>, BaseDimensionExponent>,
     type_: ItemType,
 }
 
@@ -322,7 +322,7 @@ impl From<DimensionEntry> for Item {
             }),
             Definition::Base(()) => {
                 let mut fields = HashMap::default();
-                fields.insert(entry.dimension_entry_name(), 1);
+                fields.insert(entry.dimension_entry_name(), BaseDimensionExponent::one());
                 Expr::Value(expression::Factor::Value(Factor::Concrete(
                     DimensionsAndFactor::dimensions(BaseDimensions { fields }),
                 )))

--- a/crates/diman_unit_system/src/to_snakecase.rs
+++ b/crates/diman_unit_system/src/to_snakecase.rs
@@ -1,0 +1,29 @@
+use proc_macro2::Ident;
+
+fn str_to_snakecase(s: &str) -> String {
+    let s = s.chars().rev().collect::<String>();
+    let words = s.split_inclusive(|c: char| c.is_uppercase());
+    words
+        .map(|word| word.chars().rev().collect::<String>().to_lowercase())
+        .rev()
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+pub fn to_snakecase(dim: &Ident) -> Ident {
+    let snake_case = str_to_snakecase(&dim.to_string());
+    Ident::new(&snake_case, dim.span())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn str_to_snakecase() {
+        assert_eq!(super::str_to_snakecase("MyType"), "my_type".to_owned());
+        assert_eq!(super::str_to_snakecase("My"), "my".to_owned());
+        assert_eq!(
+            super::str_to_snakecase("MyVeryLongType"),
+            "my_very_long_type".to_owned()
+        );
+    }
+}

--- a/crates/diman_unit_system/src/types.rs
+++ b/crates/diman_unit_system/src/types.rs
@@ -1,3 +1,5 @@
+mod allowed_exponent;
+
 use proc_macro2::Span;
 use syn::*;
 
@@ -9,7 +11,7 @@ use crate::{
     to_snakecase::to_snakecase,
 };
 
-pub type IntExponent = i32;
+pub use allowed_exponent::BaseDimensionExponent;
 
 #[derive(Clone)]
 pub enum Factor<C> {
@@ -29,7 +31,7 @@ impl<C1: Clone> Factor<C1> {
 #[derive(Clone)]
 pub enum Definition<Base, C> {
     Base(Base),
-    Expression(Expr<Factor<C>, IntExponent>),
+    Expression(Expr<Factor<C>, BaseDimensionExponent>),
 }
 
 pub type DimensionFactor = Factor<One>;
@@ -66,7 +68,7 @@ pub struct Symbol(pub Ident);
 #[derive(Clone)]
 pub struct ConstantEntry {
     pub name: Ident,
-    pub rhs: Expr<Factor<f64>, IntExponent>,
+    pub rhs: Expr<Factor<f64>, BaseDimensionExponent>,
     pub dimension_annotation: Option<Ident>,
 }
 

--- a/crates/diman_unit_system/src/types.rs
+++ b/crates/diman_unit_system/src/types.rs
@@ -2,11 +2,11 @@ use proc_macro2::Span;
 use syn::*;
 
 use crate::{
-    derive_dimension::to_snakecase,
     dimension_math::BaseDimensions,
     expression::{self, BinaryOperator, Expr, Operator},
     parse::One,
     prefixes::Prefix,
+    to_snakecase::to_snakecase,
 };
 
 pub type IntExponent = i32;

--- a/crates/diman_unit_system/src/types/allowed_exponent.rs
+++ b/crates/diman_unit_system/src/types/allowed_exponent.rs
@@ -1,5 +1,10 @@
 #[cfg(feature = "rational-dimensions")]
 mod reexport {
+    /// Represents a ratio between two numbers.
+    /// This is an even smaller reimplementation of the
+    /// `Ratio` type that `unit_system` implements for the calling crate.
+    /// Unfortunately, using the ratio type here is not possible, since
+    /// that would require another proc macro crate.
     #[derive(Clone, PartialEq, Copy)]
     pub struct BaseDimensionExponent {
         pub num: i32,

--- a/crates/diman_unit_system/src/types/allowed_exponent.rs
+++ b/crates/diman_unit_system/src/types/allowed_exponent.rs
@@ -1,0 +1,126 @@
+#[cfg(feature = "rational-dimensions")]
+mod reexport {
+    #[derive(Clone, PartialEq, Copy)]
+    pub struct BaseDimensionExponent {
+        pub num: i32,
+        pub denom: i32,
+    }
+
+    fn gcd(mut a: i32, mut b: i32) -> i32 {
+        while b != 0 {
+            let temp = b;
+            b = a % b;
+            a = temp;
+        }
+        a.abs()
+    }
+
+    impl BaseDimensionExponent {
+        pub fn one() -> BaseDimensionExponent {
+            Self { num: 1, denom: 1 }
+        }
+
+        pub fn zero() -> BaseDimensionExponent {
+            Self { num: 0, denom: 1 }
+        }
+
+        pub fn pow(num: f64, exponent: Self) -> f64 {
+            num.powf(exponent.num as f64 / exponent.denom as f64)
+        }
+
+        fn new(num: i32, denom: i32) -> Self {
+            let gcd = gcd(num, denom);
+            Self {
+                num: num / gcd,
+                denom: denom / gcd,
+            }
+        }
+    }
+
+    impl std::fmt::Display for BaseDimensionExponent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            if self.denom == 1 {
+                write!(f, "{}", self.num)
+            } else {
+                write!(f, "{}/{}", self.num, self.denom)
+            }
+        }
+    }
+
+    impl std::ops::Mul for BaseDimensionExponent {
+        type Output = Self;
+
+        fn mul(self, rhs: Self) -> Self::Output {
+            Self::new(self.num * rhs.num, self.denom * rhs.denom)
+        }
+    }
+
+    impl std::ops::AddAssign for BaseDimensionExponent {
+        fn add_assign(&mut self, rhs: Self) {
+            let num = self.num * rhs.denom + rhs.num * self.denom;
+            let denom = self.denom * rhs.denom;
+            *self = Self::new(num, denom)
+        }
+    }
+
+    impl std::ops::Neg for BaseDimensionExponent {
+        type Output = Self;
+
+        fn neg(self) -> Self::Output {
+            Self {
+                num: -self.num,
+                denom: self.denom,
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "rational-dimensions"))]
+mod reexport {
+    #[derive(Clone, PartialEq, Copy)]
+    pub struct BaseDimensionExponent(pub i32);
+
+    impl BaseDimensionExponent {
+        pub fn one() -> BaseDimensionExponent {
+            Self(1)
+        }
+
+        pub fn zero() -> BaseDimensionExponent {
+            Self(0)
+        }
+
+        pub fn pow(num: f64, exponent: Self) -> f64 {
+            num.powi(exponent.0)
+        }
+    }
+
+    impl std::fmt::Display for BaseDimensionExponent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::ops::Mul for BaseDimensionExponent {
+        type Output = Self;
+
+        fn mul(self, rhs: Self) -> Self::Output {
+            Self(self.0 * rhs.0)
+        }
+    }
+
+    impl std::ops::AddAssign for BaseDimensionExponent {
+        fn add_assign(&mut self, rhs: Self) {
+            self.0 += rhs.0
+        }
+    }
+
+    impl std::ops::Neg for BaseDimensionExponent {
+        type Output = Self;
+
+        fn neg(self) -> Self::Output {
+            Self(-self.0)
+        }
+    }
+}
+
+pub use reexport::BaseDimensionExponent;

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -29,6 +29,9 @@ mod serde;
 #[cfg(feature = "rand")]
 mod rand;
 
+#[cfg(feature = "rational-dimensions")]
+mod rational_dimensions;
+
 #[test]
 #[cfg(feature = "f32")]
 fn compile_fail_float() {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -9,9 +9,10 @@ mod float;
 
 mod type_aliases;
 
-mod dimension_defs;
-
 pub mod unit_aliases;
+
+#[cfg(feature = "f64")]
+mod dimension_defs;
 
 #[cfg(feature = "f64")]
 mod gas;
@@ -50,6 +51,7 @@ fn compile_fail_resolver() {
 }
 
 #[test]
+#[cfg(not(feature = "rational-dimensions"))]
 fn compile_fail_type_mismatch() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile_fail/type_mismatch_*.rs");

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -30,7 +30,7 @@ mod serde;
 mod rand;
 
 #[cfg(feature = "rational-dimensions")]
-mod rational_dimensions;
+pub mod rational_dimensions;
 
 #[test]
 #[cfg(feature = "f32")]

--- a/tests/mpi/mod.rs
+++ b/tests/mpi/mod.rs
@@ -31,6 +31,7 @@ macro_rules! gen_tests_for_float {
     };
 }
 
+#[cfg(any(feature = "glam-vec2", feature = "glam-dvec2"))]
 macro_rules! gen_tests_for_vector_2 {
     ($vec_mod_name: ident) => {
         mod $vec_mod_name {
@@ -52,6 +53,7 @@ macro_rules! gen_tests_for_vector_2 {
     };
 }
 
+#[cfg(any(feature = "glam-vec3", feature = "glam-dvec3"))]
 macro_rules! gen_tests_for_vector_3 {
     ($vec_mod_name: ident) => {
         mod $vec_mod_name {

--- a/tests/rational_dimensions/mod.rs
+++ b/tests/rational_dimensions/mod.rs
@@ -1,22 +1,42 @@
-macro_rules! gen_tests_for_float {
-    ($float_name: ident) => {
-        mod $float_name {
-            use crate::example_system::$float_name::Length;
-            use crate::example_system::$float_name::Time;
+diman::unit_system!(
+    quantity_type Quantity;
+    dimension_type Dimension;
+    dimension Length;
+    dimension Time;
+    dimension Sorptivity = Length Time^(-1/2);
 
+    #[base(Time)]
+    #[prefix(milli)]
+    unit seconds;
+
+    #[base(Length)]
+    #[prefix(micro)]
+    unit meters;
+
+    unit meters_per_sqrt_second: Sorptivity = meters / seconds^(1/2);
+);
+
+macro_rules! gen_tests_for_float {
+    ($mod_name: ident, $float_name: ident, $assert_is_close: path) => {
+        mod $mod_name {
             #[test]
             fn rational_dimensions_allowed() {
-                let x = Length::meters(1.0);
-                let y = Time::seconds(1.0);
-                let z = x.cbrt() * y;
-                dbg!(z.powi::<3>() / y.powi::<3>());
+                use super::$float_name::{Length, Sorptivity, Time};
+                let l = Length::micrometers(2.0);
+                let t = Time::milliseconds(5.0);
+                let sorptivity: Sorptivity = l / t.sqrt();
+                let val = l.value_unchecked() / t.value_unchecked().sqrt();
+                $assert_is_close(
+                    sorptivity.value_unchecked(),
+                    Sorptivity::meters_per_sqrt_second(val).value_unchecked(),
+                );
             }
         }
     };
 }
 
 #[cfg(feature = "f32")]
-gen_tests_for_float!(f32);
+gen_tests_for_float!(mod_f32, f32, crate::utils::assert_is_close_float_f32);
 
 #[cfg(feature = "f64")]
-gen_tests_for_float!(f64);
+gen_tests_for_float!(mod_f64, f64, crate::utils::assert_is_close_float_f64);

--- a/tests/rational_dimensions/mod.rs
+++ b/tests/rational_dimensions/mod.rs
@@ -1,0 +1,22 @@
+macro_rules! gen_tests_for_float {
+    ($float_name: ident) => {
+        mod $float_name {
+            use crate::example_system::$float_name::Length;
+            use crate::example_system::$float_name::Time;
+
+            #[test]
+            fn rational_dimensions_allowed() {
+                let x = Length::meters(1.0);
+                let y = Time::seconds(1.0);
+                let z = x.cbrt() * y;
+                dbg!(z.powi::<3>() / y.powi::<3>());
+            }
+        }
+    };
+}
+
+#[cfg(feature = "f32")]
+gen_tests_for_float!(f32);
+
+#[cfg(feature = "f64")]
+gen_tests_for_float!(f64);


### PR DESCRIPTION
Solves #25

This adds the `rational-dimensions` feature to use rational dimensions instead of just integer dimensions. Comes along with some minor code cleanups. I added my own very unsophisticated `Ratio` type in order not to pull in an additional dependency. 

Todo: 
- [x] add documentation for the feature
- [x] write better tests (ideally with a useful example)
- [ ] think about how to improve compiler error messages. Probably rewriting the `Ratio` struct to a tuple struct with two entries will already improve things.
- [x] add tests to CI

- [x] Allow definitions to make use of the rational dimensions so we can write `dimension SqrtLength = Length^(1/2)`
