### PR TITLE
`no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 members = ["crates/*"]
 
 [features]
+num-traits-libm = ["num-traits/libm", "diman_unit_system/num-traits-libm"]
 glam = ["dep:glam", "diman_unit_system/glam"]
 glam-vec2 = ["glam", "f32", "diman_unit_system/glam-vec2"]
 glam-dvec2 = ["glam", "f64", "diman_unit_system/glam-dvec2"]
@@ -22,6 +23,7 @@ glam-dvec3 = ["glam", "f64", "diman_unit_system/glam-dvec3"]
 f32 = ["diman_unit_system/f32"]
 f64 = ["diman_unit_system/f64"]
 gen-vec-names = ["diman_unit_system/gen-vec-names"]
+std = ["diman_unit_system/std"]
 si = []
 rational-dimensions = ["diman_unit_system/rational-dimensions"]
 
@@ -29,7 +31,7 @@ mpi = ["dep:once_cell", "dep:mpi", "diman_unit_system/mpi"]
 hdf5 = ["dep:hdf5", "diman_unit_system/hdf5"]
 rand = ["dep:rand", "diman_unit_system/rand"]
 serde = ["dep:serde", "diman_unit_system/serde"]
-default = ["f32", "f64", "si"]
+default = ["f32", "f64", "si", "std"]
 
 [lib]
 
@@ -40,6 +42,7 @@ serde = { version = "1.0.193", features = ["derive"], optional = true }
 hdf5 = { version = "0.8.1", optional = true }
 mpi = { version = "0.7", default-features = false, features = ["derive"], optional = true }
 once_cell = { version = "1.18.0", optional = true }
+num-traits = { version = "0.2.17", default-features = false }
 
 diman_unit_system = { path = "crates/diman_unit_system", version = "0.4" }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ If you cannot use unstable Rust for your project or require a stable library, co
 * Systems of dimensions and units can be user defined via the `unit_system!` macro. This gives the user complete freedom over the choice of dimensions and makes them part of the user's library, so that arbitrary new methods can be implemented on them.
 * The `rational-dimensions` features allows the usage of quantities and units with rational exponents.
 * `f32` and `f64` float storage types (behind the `f32` and `f64` feature gate respectively).
+* The `std` feature is enabled by default. If disabled, Diman will be a `no_std` crate, thus suitable for use on embedded devices such as GPU device kernels.
+* The `num-traits-libm` feature uses [libm](https://crates.io/crates/libm) to provide math functions in `no_std` environments. While one can use libm in `std`, the libm implementations are generally slower so this is unlikely to be desirable.
 * Vector storage types via [`glam`](https://crates.io/crates/glam/) (behind the `glam-vec2`, `glam-vec3`, `glam-dvec2` and `glam-dvec3` features).
 * Serialization and Deserialization via [`serde`](https://crates.io/crates/serde) (behind the `serde` feature gate, see the official documentation for more info).
 * HDF5 support using [`hdf5-rs`](https://crates.io/crates/hdf5-rs/) (behind the `hdf5` feature gate).

--- a/crates/diman_unit_system/Cargo.toml
+++ b/crates/diman_unit_system/Cargo.toml
@@ -23,6 +23,8 @@ rand = []
 hdf5 = []
 gen-vec-names = [] 
 rational-dimensions = []
+num-traits-libm = []
+std = []
 
 [dependencies]
 syn = { version = "2.0", features = ["full", "extra-traits"] }

--- a/crates/diman_unit_system/src/codegen/debug.rs
+++ b/crates/diman_unit_system/src/codegen/debug.rs
@@ -26,14 +26,11 @@ impl Defs {
         } = &self;
         let units = self.units_array(self.units.iter().filter(|unit| unit.factor == 1.0));
         quote! {
-            impl<const D: #dimension_type, S: diman::DebugStorageType + std::fmt::Display> std::fmt::Debug for #quantity_type<S, D> {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl<const D: #dimension_type, S: diman::DebugStorageType + core::fmt::Display> core::fmt::Debug for #quantity_type<S, D> {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     let closeness = |value: f64, unit_factor: f64| {
-                        if value == 0.0 {
-                            1.0
-                        } else {
-                            (value / unit_factor).abs().ln().abs()
-                        }
+                        let (mantissa, exponent, _sign) = (value / unit_factor).integer_decode();
+                        (exponent, mantissa)
                     };
                     let val = self.0.representative_value();
                     let units: &[(#dimension_type, _, _)] = &#units;
@@ -43,7 +40,7 @@ impl Defs {
                         .min_by(|(_, _, x), (_, _, y)| {
                             closeness(val, *x)
                                 .partial_cmp(&closeness(val, *y))
-                                .unwrap_or(std::cmp::Ordering::Equal)
+                                .unwrap_or(core::cmp::Ordering::Equal)
                         })
                         .map(|(_, name, val)| (name, val))
                         .unwrap_or((&"unknown unit", &1.0));

--- a/crates/diman_unit_system/src/codegen/dimension_def.rs
+++ b/crates/diman_unit_system/src/codegen/dimension_def.rs
@@ -19,7 +19,7 @@ impl Defs {
         let ratio_impl = self.ratio_impl();
         let output = quote! {
             #ratio_impl
-            #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug, ::std::marker::ConstParamTy)]
+            #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::clone::Clone, ::core::fmt::Debug, ::core::marker::ConstParamTy)]
             pub struct #name {
                 #dimensions
             }
@@ -137,7 +137,7 @@ impl Defs {
     #[cfg(feature = "rational-dimensions")]
     fn ratio_impl(&self) -> proc_macro2::TokenStream {
         quote! {
-            #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug, ::std::marker::ConstParamTy)]
+            #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::clone::Clone, ::core::fmt::Debug, ::core::marker::ConstParamTy)]
             struct Ratio {
                 num: i32,
                 denom: i32,

--- a/crates/diman_unit_system/src/codegen/traits.rs
+++ b/crates/diman_unit_system/src/codegen/traits.rs
@@ -23,16 +23,16 @@ use Trait::*;
 impl Trait {
     fn name(&self) -> TokenStream {
         match self {
-            Add => quote! { std::ops::Add },
-            Sub => quote! { std::ops::Sub },
-            Mul => quote! { std::ops::Mul },
-            Div => quote! { std::ops::Div },
-            AddAssign => quote! { std::ops::AddAssign },
-            SubAssign => quote! { std::ops::SubAssign },
-            MulAssign => quote! { std::ops::MulAssign },
-            DivAssign => quote! { std::ops::DivAssign },
-            PartialEq => quote! { std::cmp::PartialEq },
-            PartialOrd => quote! { std::cmp::PartialOrd },
+            Add => quote! { core::ops::Add },
+            Sub => quote! { core::ops::Sub },
+            Mul => quote! { core::ops::Mul },
+            Div => quote! { core::ops::Div },
+            AddAssign => quote! { core::ops::AddAssign },
+            SubAssign => quote! { core::ops::SubAssign },
+            MulAssign => quote! { core::ops::MulAssign },
+            DivAssign => quote! { core::ops::DivAssign },
+            PartialEq => quote! { core::cmp::PartialEq },
+            PartialOrd => quote! { core::cmp::PartialOrd },
         }
     }
 
@@ -58,7 +58,7 @@ impl Trait {
                 quote! { () }
             }
             PartialEq => quote! { bool },
-            PartialOrd => quote! { Option<std::cmp::Ordering> },
+            PartialOrd => quote! { Option<core::cmp::Ordering> },
         }
     }
 
@@ -677,7 +677,7 @@ impl Defs {
             ..
         } = self;
         quote! {
-            impl<const D: #dimension_type, S: Default + std::ops::AddAssign<S>> std::iter::Sum
+            impl<const D: #dimension_type, S: Default + core::ops::AddAssign<S>> core::iter::Sum
                 for #quantity_type<S, D>
             {
                 fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -699,7 +699,7 @@ impl Defs {
             ..
         } = self;
         quote! {
-            impl<const D: #dimension_type, S: std::ops::Neg<Output=S>> std::ops::Neg for #quantity_type<S, D> {
+            impl<const D: #dimension_type, S: core::ops::Neg<Output=S>> core::ops::Neg for #quantity_type<S, D> {
                 type Output = Self;
 
                 fn neg(self) -> Self::Output {

--- a/crates/diman_unit_system/src/codegen/type_defs.rs
+++ b/crates/diman_unit_system/src/codegen/type_defs.rs
@@ -52,7 +52,7 @@ impl Defs {
                 }
             }
 
-            impl<S> std::ops::Deref for #quantity_type<S, { #dimension_type::none() }> {
+            impl<S> core::ops::Deref for #quantity_type<S, { #dimension_type::none() }> {
                 type Target = S;
 
                 fn deref(&self) -> &Self::Target {

--- a/crates/diman_unit_system/src/dimension_math.rs
+++ b/crates/diman_unit_system/src/dimension_math.rs
@@ -28,7 +28,7 @@ impl BaseDimensions {
     }
 }
 
-impl std::ops::Mul for BaseDimensions {
+impl core::ops::Mul for BaseDimensions {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -55,7 +55,7 @@ impl BaseDimensions {
     }
 }
 
-impl std::ops::Div for BaseDimensions {
+impl core::ops::Div for BaseDimensions {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -98,7 +98,7 @@ impl DimensionsAndFactor {
     }
 }
 
-impl std::ops::Mul for DimensionsAndFactor {
+impl core::ops::Mul for DimensionsAndFactor {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -109,7 +109,7 @@ impl std::ops::Mul for DimensionsAndFactor {
     }
 }
 
-impl std::ops::Div for DimensionsAndFactor {
+impl core::ops::Div for DimensionsAndFactor {
     type Output = Self;
 
     fn div(self, rhs: Self) -> Self::Output {

--- a/crates/diman_unit_system/src/expression.rs
+++ b/crates/diman_unit_system/src/expression.rs
@@ -42,7 +42,7 @@ pub enum Factor<T, E> {
 }
 
 pub trait MulDiv:
-    std::ops::Mul<Output = Self> + std::ops::Div<Output = Self> + Sized + Clone
+    core::ops::Mul<Output = Self> + core::ops::Div<Output = Self> + Sized + Clone
 {
     fn pow(self, pow: BaseDimensionExponent) -> Self;
 }
@@ -115,9 +115,9 @@ impl<T, E> Factor<T, E> {
 
     pub fn iter_vals<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
         match self {
-            Factor::Value(val) => Box::new(std::iter::once(val)),
+            Factor::Value(val) => Box::new(core::iter::once(val)),
             Factor::ParenExpr(expr) => expr.iter_vals(),
-            Factor::Power(val, _) => Box::new(std::iter::once(val)),
+            Factor::Power(val, _) => Box::new(core::iter::once(val)),
         }
     }
 }
@@ -156,7 +156,7 @@ mod tests {
 
     use super::{super::parse::tests::parse_expr, MulDiv};
 
-    impl std::ops::Mul for MyInt {
+    impl core::ops::Mul for MyInt {
         type Output = MyInt;
 
         fn mul(self, rhs: Self) -> Self::Output {
@@ -164,7 +164,7 @@ mod tests {
         }
     }
 
-    impl std::ops::Div for MyInt {
+    impl core::ops::Div for MyInt {
         type Output = MyInt;
 
         fn div(self, rhs: Self) -> Self::Output {

--- a/crates/diman_unit_system/src/types/allowed_exponent.rs
+++ b/crates/diman_unit_system/src/types/allowed_exponent.rs
@@ -42,8 +42,8 @@ mod reexport {
         }
     }
 
-    impl std::fmt::Display for BaseDimensionExponent {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl core::fmt::Display for BaseDimensionExponent {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             if self.denom == 1 {
                 write!(f, "{}", self.num)
             } else {
@@ -52,7 +52,7 @@ mod reexport {
         }
     }
 
-    impl std::ops::Mul for BaseDimensionExponent {
+    impl core::ops::Mul for BaseDimensionExponent {
         type Output = Self;
 
         fn mul(self, rhs: Self) -> Self::Output {
@@ -60,7 +60,7 @@ mod reexport {
         }
     }
 
-    impl std::ops::AddAssign for BaseDimensionExponent {
+    impl core::ops::AddAssign for BaseDimensionExponent {
         fn add_assign(&mut self, rhs: Self) {
             let num = self.num * rhs.denom + rhs.num * self.denom;
             let denom = self.denom * rhs.denom;
@@ -68,7 +68,7 @@ mod reexport {
         }
     }
 
-    impl std::ops::Neg for BaseDimensionExponent {
+    impl core::ops::Neg for BaseDimensionExponent {
         type Output = Self;
 
         fn neg(self) -> Self::Output {
@@ -99,13 +99,13 @@ mod reexport {
         }
     }
 
-    impl std::fmt::Display for BaseDimensionExponent {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl core::fmt::Display for BaseDimensionExponent {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             write!(f, "{}", self.0)
         }
     }
 
-    impl std::ops::Mul for BaseDimensionExponent {
+    impl core::ops::Mul for BaseDimensionExponent {
         type Output = Self;
 
         fn mul(self, rhs: Self) -> Self::Output {
@@ -113,13 +113,13 @@ mod reexport {
         }
     }
 
-    impl std::ops::AddAssign for BaseDimensionExponent {
+    impl core::ops::AddAssign for BaseDimensionExponent {
         fn add_assign(&mut self, rhs: Self) {
             self.0 += rhs.0
         }
     }
 
-    impl std::ops::Neg for BaseDimensionExponent {
+    impl core::ops::Neg for BaseDimensionExponent {
         type Output = Self;
 
         fn neg(self) -> Self::Output {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,18 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs, adt_const_params)]
 #![doc = include_str!("../README.md")]
 
 mod debug_storage_type;
 mod type_aliases;
+
+#[cfg(all(
+    feature = "rational-dimensions",
+    not(any(feature = "std", feature = "num-traits-libm"))
+))]
+compile_error!(
+    "The \"rational-dimensions\" feature requires either \"std\" or \"num-traits-libm\""
+);
 
 #[cfg(feature = "si")]
 /// Defines the dimensions and units for the SI system.

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -21,7 +21,7 @@ pub type Product<Q1> = <Q1 as QProduct>::Output;
 /// let x: Quotient<Length, Time> = Length::meters(10.0) / Time::seconds(2.0);
 /// ```
 pub type Quotient<Q1, Q2> =
-    <<Q1 as QProduct>::Output as std::ops::Div<<Q2 as QProduct>::Output>>::Output;
+    <<Q1 as QProduct>::Output as core::ops::Div<<Q2 as QProduct>::Output>>::Output;
 
 macro_rules! impl_qproduct {
     ($f: ident, $($fs: ident),+) => {
@@ -29,10 +29,10 @@ macro_rules! impl_qproduct {
         where
             ($($fs),+): QProduct,
             $f: QProduct,
-            <($($fs),+) as QProduct>::Output: std::ops::Mul<<$f as QProduct>::Output>,
+            <($($fs),+) as QProduct>::Output: core::ops::Mul<<$f as QProduct>::Output>,
         {
             type Output =
-                <<($($fs),+) as QProduct>::Output as std::ops::Mul<<$f as QProduct>::Output>>::Output;
+                <<($($fs),+) as QProduct>::Output as core::ops::Mul<<$f as QProduct>::Output>>::Output;
         }
 
     }
@@ -42,9 +42,9 @@ impl<Q1, Q2> QProduct for (Q1, Q2)
 where
     Q1: QProduct,
     Q2: QProduct,
-    <Q1 as QProduct>::Output: std::ops::Mul<<Q2 as QProduct>::Output>,
+    <Q1 as QProduct>::Output: core::ops::Mul<<Q2 as QProduct>::Output>,
 {
-    type Output = <<Q1 as QProduct>::Output as std::ops::Mul<<Q2 as QProduct>::Output>>::Output;
+    type Output = <<Q1 as QProduct>::Output as core::ops::Mul<<Q2 as QProduct>::Output>>::Output;
 }
 
 impl_qproduct!(Q1, Q2, Q3);

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -14,6 +14,7 @@ pub mod unit_aliases;
 #[cfg(feature = "f64")]
 mod dimension_defs;
 
+#[cfg(feature = "si")]
 #[cfg(feature = "f64")]
 mod gas;
 
@@ -33,7 +34,7 @@ mod rand;
 pub mod rational_dimensions;
 
 #[test]
-#[cfg(feature = "f32")]
+#[cfg(feature = "f64")]
 fn compile_fail_float() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile_fail/float_*.rs");
@@ -48,12 +49,15 @@ fn compile_fail_glam() {
 }
 
 #[test]
+#[cfg(feature = "f64")]
 fn compile_fail_resolver() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile_fail/resolver_*.rs");
 }
 
 #[test]
+#[cfg(feature = "f64")]
+#[cfg(feature = "si")]
 #[cfg(not(feature = "rational-dimensions"))]
 fn compile_fail_type_mismatch() {
     let t = trybuild::TestCases::new();

--- a/tests/float/mod.rs
+++ b/tests/float/mod.rs
@@ -493,6 +493,7 @@ macro_rules! gen_tests_for_float {
                 assert_is_close_float(x, 3.0);
             }
 
+            #[cfg(any(feature = "std", feature = "num-traits-libm"))]
             #[test]
             fn sqrt_float_quantity() {
                 let x = Length::meters(6.0).powi::<2>();
@@ -500,6 +501,7 @@ macro_rules! gen_tests_for_float {
                 assert_is_close((x / y).sqrt(), Velocity::meters_per_second(3.0));
             }
 
+            #[cfg(any(feature = "std", feature = "num-traits-libm"))]
             #[test]
             fn cbrt_float_quantity() {
                 let x = Length::meters(4.0).powi::<3>();
@@ -514,6 +516,7 @@ macro_rules! gen_tests_for_float {
                 assert_is_close(SOLAR_MASS_AWKWARD, Mass::kilograms(1.988477e30));
             }
 
+            #[cfg(any(feature = "std", feature = "num-traits-libm"))]
             #[test]
             fn log2() {
                 let x = Dimensionless::dimensionless(128.0);


### PR DESCRIPTION
This is kinda rough currently, but I've tested it in several modes. There are three new features, which we might want to pare down.

* `std` (default, all float methods are available)
* `float` (use `num-traits` with `libm` so that all float methods are available in `no_std` environments. In the future, I anticipate `num-traits` will have other features to use target-specific math libraries (e.g., `libdevice` for nvptx64-nvidia-cuda).
* `float_core` (uses `num-traits` with minimal features -- provides some basic float methods, but not the numerical math functions)

There are a couple hiccups when none of these features are available -- I'll comment on those shortly.