### PR TITLE
Make num-traits-dependency implicit by re-exporting it from diman

### DIFF
--- a/crates/diman_lib/Cargo.toml
+++ b/crates/diman_lib/Cargo.toml
@@ -10,3 +10,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/tehforsch/diman"
 
 [dependencies]
+
+[dev-dependencies]
+num-traits = { version = "0.2.17", default-features = false }

--- a/crates/diman_unit_system/src/codegen/dimension_type.rs
+++ b/crates/diman_unit_system/src/codegen/dimension_type.rs
@@ -162,26 +162,27 @@ impl Codegen {
     }
 
     fn use_exponent_and_dimension_exponent_trait(&self) -> TokenStream {
+        let path_prefix = self.caller_type.path_prefix();
         let use_exponent = match self.caller_type {
             CallerType::External => {
                 #[cfg(feature = "rational-dimensions")]
-                quote! { use ::diman::internal::Ratio as Exponent; }
+                quote! { use #path_prefix::ratio::Ratio as Exponent; }
                 #[cfg(not(feature = "rational-dimensions"))]
                 quote! { use i64 as Exponent; }
             }
             CallerType::Internal => {
                 #[cfg(feature = "rational-dimensions")]
-                quote! { use ::diman_lib::ratio::Ratio as Exponent; }
+                quote! { use #path_prefix::::ratio::Ratio as Exponent; }
                 #[cfg(not(feature = "rational-dimensions"))]
                 quote! { use i64 as Exponent; }
             }
         };
         let use_dimension_exponent_trait = match self.caller_type {
             CallerType::External => {
-                quote! { use ::diman::internal::DimensionExponent; }
+                quote! { use #path_prefix::dimension_exponent::DimensionExponent; }
             }
             CallerType::Internal => {
-                quote! { use ::diman_lib::dimension_exponent::DimensionExponent; }
+                quote! { use #path_prefix::dimension_exponent::DimensionExponent; }
             }
         };
         quote! {

--- a/crates/diman_unit_system/src/codegen/float_methods.rs
+++ b/crates/diman_unit_system/src/codegen/float_methods.rs
@@ -1,17 +1,21 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{join, storage_types::FloatType, Codegen};
+use super::{join, storage_types::FloatType, CallerType, Codegen};
 
 impl Codegen {
     fn ensure_float_traits(&self) -> TokenStream {
+        let path_prefix = match self.caller_type {
+            CallerType::Internal => quote! { ::num_traits::float },
+            CallerType::External => quote! { diman::internal::num_traits_reexport },
+        };
         if cfg!(feature = "num-traits-libm") {
             quote! {
-                use num_traits::float::Float;
+                use #path_prefix::Float;
             }
         } else {
             quote! {
-                use num_traits::float::FloatCore;
+                use #path_prefix::FloatCore;
             }
         }
     }

--- a/crates/diman_unit_system/src/codegen/mod.rs
+++ b/crates/diman_unit_system/src/codegen/mod.rs
@@ -17,6 +17,7 @@ mod units;
 mod vector_methods;
 
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::types::Defs;
 
@@ -28,6 +29,15 @@ pub enum CallerType {
     /// The macro is called from somewhere else (`diman` or a user's crate)
     /// and imports need to be from `diman`.
     External,
+}
+
+impl CallerType {
+    fn path_prefix(&self) -> TokenStream {
+        match self {
+            CallerType::Internal => quote! { ::diman_lib },
+            CallerType::External => quote! { ::diman::internal },
+        }
+    }
 }
 
 pub struct Codegen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,11 @@ pub type Product<Q1, Q2> = <Q1 as ::core::ops::Mul<Q2>>::Output;
 pub type Quotient<Q1, Q2> = <Q1 as core::ops::Div<Q2>>::Output;
 
 pub mod internal {
-    pub use diman_lib::dimension_exponent::DimensionExponent;
-    pub use diman_lib::ratio::Ratio;
-    pub use diman_lib::runtime_unit_storage;
+    pub use diman_lib::*;
+    pub mod num_traits_reexport {
+        #[cfg(feature = "num-traits-libm")]
+        pub use num_traits::float::Float;
+        #[cfg(not(feature = "num-traits-libm"))]
+        pub use num_traits::float::FloatCore;
+    }
 }


### PR DESCRIPTION
This fixes requiring the user to have a num-traits dependency when `unit_system!` is used.