### PR TITLE
Adapt to new compiler error format.

### DIFF
--- a/crates/diman_unit_system/src/parse/attributes.rs
+++ b/crates/diman_unit_system/src/parse/attributes.rs
@@ -134,7 +134,7 @@ impl Parse for Alias {
     }
 }
 
-impl<'a> Attribute<'a> {
+impl Attribute<'_> {
     fn inner_or_err(&self) -> Result<&ParseBuffer> {
         self.inner
             .as_ref()

--- a/crates/diman_unit_system/src/resolve/error.rs
+++ b/crates/diman_unit_system/src/resolve/error.rs
@@ -123,7 +123,7 @@ fn format_lhs_rhs_dimensions(lhs: &BaseDimensions, rhs: &BaseDimensions) -> (Str
     (format(lhs), format(rhs))
 }
 
-impl<'a> Emit for ViolatedAnnotationError<'a> {
+impl Emit for ViolatedAnnotationError<'_> {
     fn emit(self) {
         // In the future, it would be nice to have a proper span for the
         // second help text that points to the rhs. Unfortunately, joining
@@ -146,7 +146,7 @@ impl<'a> Emit for ViolatedAnnotationError<'a> {
     }
 }
 
-impl<'a> Emit for UndefinedAnnotationDimensionError<'a> {
+impl Emit for UndefinedAnnotationDimensionError<'_> {
     fn emit(self) {
         self.0
             .span()
@@ -199,7 +199,7 @@ impl Emit for MultipleDefinitionsError {
     }
 }
 
-impl<'a> Emit for KindNotAllowedError<'a> {
+impl Emit for KindNotAllowedError<'_> {
     fn emit(self) {
         let name = |kind| match kind {
             Kind::Dimension => "Dimension",
@@ -242,7 +242,7 @@ impl<'a> Emit for KindNotAllowedError<'a> {
     }
 }
 
-impl<'a> Emit for WrongTypeInAnnotationError<'a> {
+impl Emit for WrongTypeInAnnotationError<'_> {
     fn emit(self) {
         let name = match self.annotation_kind {
             Kind::Dimension => unreachable!(),
@@ -262,7 +262,7 @@ impl<'a> Emit for WrongTypeInAnnotationError<'a> {
     }
 }
 
-impl<'a> Emit for MultipleBaseUnitsForDimensionError<'a> {
+impl Emit for MultipleBaseUnitsForDimensionError<'_> {
     fn emit(self) {
         self.unit
             .span()
@@ -277,7 +277,7 @@ impl<'a> Emit for MultipleBaseUnitsForDimensionError<'a> {
     }
 }
 
-impl<'a> Emit for BaseUnitForNonBaseDimensionError<'a> {
+impl Emit for BaseUnitForNonBaseDimensionError<'_> {
     fn emit(self) {
         self.unit
             .span()
@@ -293,7 +293,7 @@ impl<'a> Emit for BaseUnitForNonBaseDimensionError<'a> {
     }
 }
 
-impl<'a> Emit for SymbolDefinedMultipleTimes<'a> {
+impl Emit for SymbolDefinedMultipleTimes<'_> {
     fn emit(self) {
         Diagnostic::spanned(
             self.units
@@ -307,7 +307,7 @@ impl<'a> Emit for SymbolDefinedMultipleTimes<'a> {
     }
 }
 
-impl<'a> Emit for NoSymbolForBaseUnitError<'a> {
+impl Emit for NoSymbolForBaseUnitError<'_> {
     fn emit(self) {
         self.0
             .name

--- a/crates/diman_unit_system/tests/compile_fail/type_mismatch_add_type_quantity.stderr
+++ b/crates/diman_unit_system/tests/compile_fail/type_mismatch_add_type_quantity.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<f64 as Add<Quantity<f64, Dimension>>>::O
  --> tests/compile_fail/type_mismatch_add_type_quantity.rs:7:21
   |
 7 |     let x: () = 1.0 + dimensionless.new(1.0);
-  |                     ^ expected `Quantity<f64, Dimension>`, found `()`
+  |                     ^ expected `()`, found `Quantity<f64, Dimension>`
   |
-  = note: expected struct `Quantity<f64, Dimension>`
-          found unit type `()`
+  = note: expected unit type `()`
+                found struct `Quantity<f64, Dimension>`

--- a/crates/diman_unit_system/tests/compile_fail/type_mismatch_div_quantity_type.stderr
+++ b/crates/diman_unit_system/tests/compile_fail/type_mismatch_div_quantity_type.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<f64 as Div<Quantity<f64, Dimension>>>::O
  --> tests/compile_fail/type_mismatch_div_quantity_type.rs:7:21
   |
 7 |     let x: () = 1.0 / dimensionless.new(1.0);
-  |                     ^ expected `Quantity<f64, Dimension>`, found `()`
+  |                     ^ expected `()`, found `Quantity<f64, Dimension>`
   |
-  = note: expected struct `Quantity<f64, Dimension>`
-          found unit type `()`
+  = note: expected unit type `()`
+                found struct `Quantity<f64, Dimension>`

--- a/crates/diman_unit_system/tests/compile_fail/type_mismatch_div_type_quantity.stderr
+++ b/crates/diman_unit_system/tests/compile_fail/type_mismatch_div_type_quantity.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Quantity<f64, Dimension> as Div<f64>>::O
  --> tests/compile_fail/type_mismatch_div_type_quantity.rs:7:40
   |
 7 |     let x: () = dimensionless.new(1.0) / 1.0;
-  |                                        ^ expected `Quantity<f64, Dimension>`, found `()`
+  |                                        ^ expected `()`, found `Quantity<f64, Dimension>`
   |
-  = note: expected struct `Quantity<f64, Dimension>`
-          found unit type `()`
+  = note: expected unit type `()`
+                found struct `Quantity<f64, Dimension>`

--- a/crates/diman_unit_system/tests/compile_fail/type_mismatch_mul_quantity_type.stderr
+++ b/crates/diman_unit_system/tests/compile_fail/type_mismatch_mul_quantity_type.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<f64 as Mul<Quantity<f64, Dimension>>>::O
  --> tests/compile_fail/type_mismatch_mul_quantity_type.rs:7:21
   |
 7 |     let x: () = 1.0 * dimensionless.new(1.0);
-  |                     ^ expected `Quantity<f64, Dimension>`, found `()`
+  |                     ^ expected `()`, found `Quantity<f64, Dimension>`
   |
-  = note: expected struct `Quantity<f64, Dimension>`
-          found unit type `()`
+  = note: expected unit type `()`
+                found struct `Quantity<f64, Dimension>`

--- a/crates/diman_unit_system/tests/compile_fail/type_mismatch_mul_type_quantity.stderr
+++ b/crates/diman_unit_system/tests/compile_fail/type_mismatch_mul_type_quantity.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Quantity<f64, Dimension> as Mul<f64>>::O
  --> tests/compile_fail/type_mismatch_mul_type_quantity.rs:7:40
   |
 7 |     let x: () = dimensionless.new(1.0) * 1.0;
-  |                                        ^ expected `Quantity<f64, Dimension>`, found `()`
+  |                                        ^ expected `()`, found `Quantity<f64, Dimension>`
   |
-  = note: expected struct `Quantity<f64, Dimension>`
-          found unit type `()`
+  = note: expected unit type `()`
+                found struct `Quantity<f64, Dimension>`


### PR DESCRIPTION
In the new error structure, mismatched types are ordered the other way around.